### PR TITLE
Merge 17-dependencyinjection-fails-validation-for-events-although-events-not-used into main

### DIFF
--- a/src/EventSourcing.Abstractions/EventSourcing.Abstractions.csproj
+++ b/src/EventSourcing.Abstractions/EventSourcing.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Version>1.0.0-beta-2</Version>
@@ -14,7 +14,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageTags>EventSourcing, Events, EventStore</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>1.0.0-beta-6</PackageVersion>
+        <PackageVersion>1.0.0-preview-20240513-0708</PackageVersion>
         <PackageReleaseNotes>Braking Changes - New Mapper Logic</PackageReleaseNotes>
         <RootNamespace>EventSourcing</RootNamespace>
     </PropertyGroup>

--- a/src/EventSourcing.Publishers.RabbitMQ/EventSourcing.Publishers.RabbitMQ.csproj
+++ b/src/EventSourcing.Publishers.RabbitMQ/EventSourcing.Publishers.RabbitMQ.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>1.0.0-beta006</Version>
+        <Version>1.0.0-preview-20240513-0708</Version>
         <Title>EventSourcing.Publishers.RabbitMQ</Title>
         <Authors>Andreas Naumann</Authors>
         <Description>Extend the event sourcing system with RabbitMQ. 

--- a/src/EventSourcing.Publishers/EventSourcing.Publishers.csproj
+++ b/src/EventSourcing.Publishers/EventSourcing.Publishers.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>1.0.0-beta006</Version>
+        <Version>1.0.0-preview-20240513-0708</Version>
         <Title>EventSourcing.Publishers</Title>
         <Authors>Andreas Naumann</Authors>
         <Description>Extend the event sourcing system with publishers like Mqtt or RabbitMQ</Description>

--- a/src/EventSourcing/DI/EventMappingOptions.cs
+++ b/src/EventSourcing/DI/EventMappingOptions.cs
@@ -1,0 +1,3 @@
+namespace Microsoft.Extensions.DependencyInjection;
+
+public record EventMappingOptions(IServiceCollection Services, IEnumerable<Type> CoveredEvents, IEnumerable<Type>? UncoveredEvents = null);

--- a/src/EventSourcing/DI/EventProjectionOptions.cs
+++ b/src/EventSourcing/DI/EventProjectionOptions.cs
@@ -1,0 +1,3 @@
+namespace Microsoft.Extensions.DependencyInjection;
+
+public record EventProjectionOptions(IServiceCollection Services, IEnumerable<Type> CoveredEvents, IEnumerable<Type>? UncoveredEvents);

--- a/src/EventSourcing/EventSourcing.csproj
+++ b/src/EventSourcing/EventSourcing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -17,7 +17,7 @@ The persistance is based on the EntityFramworkCore and can be configured via Dep
         <RepositoryUrl>https://github.com/mrmorrandir/EventSourcing</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageTags>EventSourcing, Events, EventStore</PackageTags>
-        <PackageVersion>1.0.0-beta-6</PackageVersion>
+        <PackageVersion>1.0.0-preview-20240513-0708</PackageVersion>
         <PackageReleaseNotes>Breaking Changes - New Mapper Logic</PackageReleaseNotes>
     </PropertyGroup>
 
@@ -27,15 +27,16 @@ The persistance is based on the EntityFramworkCore and can be configured via Dep
 
     <ItemGroup>
       <PackageReference Include="FluentResults" Version="3.15.1" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.2">
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.2" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.2" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-      <PackageReference Include="System.Text.Json" Version="7.0.1" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+      <PackageReference Include="System.Text.Json" Version="8.0.3" />
     </ItemGroup>
 
 </Project>

--- a/tests/EventSourcing.Benchmarks/EventSourcing.Benchmarks.csproj
+++ b/tests/EventSourcing.Benchmarks/EventSourcing.Benchmarks.csproj
@@ -2,15 +2,16 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.2" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/EventSourcing.FunctionTests.DI.InvalidAssembly/EventSourcing.FunctionTests.DI.InvalidAssembly.csproj
+++ b/tests/EventSourcing.FunctionTests.DI.InvalidAssembly/EventSourcing.FunctionTests.DI.InvalidAssembly.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/tests/EventSourcing.FunctionTests.DI.InvalidAssembly2/EventSourcing.FunctionTests.DI.InvalidAssembly2.csproj
+++ b/tests/EventSourcing.FunctionTests.DI.InvalidAssembly2/EventSourcing.FunctionTests.DI.InvalidAssembly2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/tests/EventSourcing.FunctionTests.DI.ValidAssembly/EventSourcing.FunctionTests.DI.ValidAssembly.csproj
+++ b/tests/EventSourcing.FunctionTests.DI.ValidAssembly/EventSourcing.FunctionTests.DI.ValidAssembly.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/tests/EventSourcing.FunctionTests.DI/DependencyInjectionTests.cs
+++ b/tests/EventSourcing.FunctionTests.DI/DependencyInjectionTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using EventSourcing.Mappers;
 using EventSourcing.Projections;
 using EventSourcing.Publishers.RabbitMQPublisher;
+using EventSourcing.Repositories;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -23,6 +24,7 @@ public class DependencyInjectionTests
 
         var eventMappers = provider.GetRequiredService<IEnumerable<IEventMapper>>().ToArray();
         var projections = provider.GetRequiredService<IEnumerable<IEventHandler>>().Select(s => (IEventHandler)s).ToList();
+        var eventRepository = provider.GetRequiredService<IEventRepository>();
         
         eventMappers.Should().ContainSingle(m => m.Types.Contains("my-custom-event-v1") && m.EventType == typeof(ValidAssembly.Events.CustomEvent));
         eventMappers.Should().ContainSingle(m => m.Types.Contains("default-event-v1") && m.EventType == typeof(ValidAssembly.Events.DefaultEvent));

--- a/tests/EventSourcing.FunctionTests.DI/EventSourcing.FunctionTests.DI.csproj
+++ b/tests/EventSourcing.FunctionTests.DI/EventSourcing.FunctionTests.DI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -11,8 +11,9 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.11.0" />
         <PackageReference Include="FluentResults" Version="3.15.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.2" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/EventSourcing.FunctionTests/EventSourcing.FunctionTests.csproj
+++ b/tests/EventSourcing.FunctionTests/EventSourcing.FunctionTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -10,8 +10,9 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.9.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.2" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/tests/EventSourcing.FunctionTests/Mappers/EventRegistryTests.cs
+++ b/tests/EventSourcing.FunctionTests/Mappers/EventRegistryTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Text.Json;
 using EventSourcing.Mappers;
 using EventSourcing.Repositories;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using JsonConverter = System.Text.Json.Serialization.JsonConverter;
@@ -17,6 +18,7 @@ public class EventRegistryTests
         var services = new ServiceCollection();
         services.AddEventSourcing(config =>
         {
+            config.ConfigureEventStoreDbContext(options => options.UseInMemoryDatabase("Test"));
             config.ConfigureMapping(options => options.AddMapper<MagicEventMapper>());
             config.ConfigureProjections(options => options.IgnoreUncoveredEvents());
         });
@@ -35,6 +37,7 @@ public class EventRegistryTests
         var services = new ServiceCollection();
         services.AddEventSourcing(config =>
         {
+            config.ConfigureEventStoreDbContext(options => options.UseInMemoryDatabase("Test"));
             config.ConfigureMapping(options => options.AddMapper<MagicEventMapper>());
             config.ConfigureProjections(options => options.IgnoreUncoveredEvents());
         });
@@ -60,6 +63,7 @@ public class EventRegistryTests
         var services = new ServiceCollection();
         services.AddEventSourcing(config =>
         {
+            config.ConfigureEventStoreDbContext(options => options.UseInMemoryDatabase("Test"));
             config.ConfigureMapping(options => options.AddMapper<MagicEventMapper>());
             config.ConfigureProjections(options => options.IgnoreUncoveredEvents());
         });
@@ -82,6 +86,7 @@ public class EventRegistryTests
         var services = new ServiceCollection();
         services.AddEventSourcing(config =>
         {
+            config.ConfigureEventStoreDbContext(options => options.UseInMemoryDatabase("Test"));
             config.ConfigureMapping(options => options.AddMapper<MagicEventMapper>());
             config.ConfigureProjections(options => options.IgnoreUncoveredEvents());
         });
@@ -104,6 +109,7 @@ public class EventRegistryTests
         var services = new ServiceCollection();
         services.AddEventSourcing(config =>
         {
+            config.ConfigureEventStoreDbContext(options => options.UseInMemoryDatabase("Test"));
             config.ConfigureMapping(options => options.AddMapper<MagicEventMapper>());
             config.ConfigureProjections(options => options.IgnoreUncoveredEvents());
         });
@@ -123,6 +129,7 @@ public class EventRegistryTests
         var services = new ServiceCollection();
         services.AddEventSourcing(config =>
         {
+            config.ConfigureEventStoreDbContext(options => options.UseInMemoryDatabase("Test"));
             config.ConfigureMapping(options => options.AddMapper<MagicEventMapper>());
             config.ConfigureProjections(options => options.IgnoreUncoveredEvents());
         });

--- a/tests/EventSourcing.Publishers.RabbitMQ.IntegrationTests/EventSourcing.Publishers.RabbitMQ.IntegrationTests.csproj
+++ b/tests/EventSourcing.Publishers.RabbitMQ.IntegrationTests/EventSourcing.Publishers.RabbitMQ.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -11,8 +11,9 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.11.0" />
         <PackageReference Include="FluentResults" Version="3.15.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.2" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
[BugFix: DependencyInjection for mapping and projections.](https://github.com/mrmorrandir/EventSourcing/commit/c03cb96176b8b144e18c0d801b77da653a1d347d)